### PR TITLE
overlay: Disable SIM batch operations

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -276,4 +276,7 @@
          provisioning, availability etc -->
     <bool name="config_carrier_volte_available">true</bool>
 
+    <!-- Configuration to support SIM contact batch operation -->
+    <bool name="config_sim_phonebook_batch_operation">false</bool>
+
 </resources>


### PR DESCRIPTION
This feature appears to be unsupported, so disable it to allow
importing SIM contacts. Exporting contacts is not possible at
the moment without batch support.

BUGBASH-592

Change-Id: If0d6506d59c9aeeab83acd7b2805b0de12b05c4b